### PR TITLE
Fix for using hyperlinks in the FTL files

### DIFF
--- a/dist/bundle/gecko/l20n.js
+++ b/dist/bundle/gecko/l20n.js
@@ -550,7 +550,7 @@ const ALLOWED_ELEMENTS = {
 const ALLOWED_ATTRIBUTES = {
   'http://www.w3.org/1999/xhtml': {
     global: ['title', 'aria-label', 'aria-valuetext', 'aria-moz-hint'],
-    a: ['download'],
+    a: ['href', 'download'],
     area: ['download', 'alt'],
     // value is special-cased in isAttrAllowed
     input: ['alt', 'placeholder'],

--- a/dist/bundle/testing/l20n.js
+++ b/dist/bundle/testing/l20n.js
@@ -2524,7 +2524,7 @@ const ALLOWED_ELEMENTS = {
 const ALLOWED_ATTRIBUTES = {
   'http://www.w3.org/1999/xhtml': {
     global: ['title', 'aria-label', 'aria-valuetext', 'aria-moz-hint'],
-    a: ['download'],
+    a: ['href', 'download'],
     area: ['download', 'alt'],
     // value is special-cased in isAttrAllowed
     input: ['alt', 'placeholder'],

--- a/dist/bundle/web/l20n.js
+++ b/dist/bundle/web/l20n.js
@@ -2982,7 +2982,7 @@ const ALLOWED_ELEMENTS = {
 const ALLOWED_ATTRIBUTES = {
   'http://www.w3.org/1999/xhtml': {
     global: ['title', 'aria-label', 'aria-valuetext', 'aria-moz-hint'],
-    a: ['download'],
+    a: ['href', 'download'],
     area: ['download', 'alt'],
     // value is special-cased in isAttrAllowed
     input: ['alt', 'placeholder'],

--- a/dist/compat/web/l20n.js
+++ b/dist/compat/web/l20n.js
@@ -3731,7 +3731,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
   var ALLOWED_ATTRIBUTES = {
     'http://www.w3.org/1999/xhtml': {
       global: ['title', 'aria-label', 'aria-valuetext', 'aria-moz-hint'],
-      a: ['download'],
+      a: ['href', 'download'],
       area: ['download', 'alt'],
       // value is special-cased in isAttrAllowed
       input: ['alt', 'placeholder'],

--- a/src/bindings/overlay.js
+++ b/src/bindings/overlay.js
@@ -14,7 +14,7 @@ const ALLOWED_ELEMENTS = {
 const ALLOWED_ATTRIBUTES = {
   'http://www.w3.org/1999/xhtml': {
     global: ['title', 'aria-label', 'aria-valuetext', 'aria-moz-hint'],
-    a: ['download'],
+    a: ['href', 'download'],
     area: ['download', 'alt'],
     // value is special-cased in isAttrAllowed
     input: ['alt', 'placeholder'],


### PR DESCRIPTION
ALLOWED_ATTRIBUTES for `a` did not have attribute `href` - that is why hyperlinks did not work in the FTL files.